### PR TITLE
Fix GroupNotiField missing return and ArcTextComplication null pointer / unexpected type error

### DIFF
--- a/source/complication/ArcTextComplication.mc
+++ b/source/complication/ArcTextComplication.mc
@@ -127,11 +127,10 @@ class ArcTextComplication extends Ui.Drawable {
 
    hidden function drawArcText(dc, text) {
       var totalChar = 0;
-      try {
+      if (text instanceof String) {
          totalChar = text.length();
-      } catch (ex) {
-         // Hit an exception for some reason
-         // Display "ERR"
+      } else {
+         // Error
          text = "ERR";
          totalChar = text.length();
       }

--- a/source/datafield/PhoneData.mc
+++ b/source/datafield/PhoneData.mc
@@ -40,6 +40,12 @@ class GroupNotiField extends BaseDataField {
       value = settings.alarmCount;
       var alarm_str = Lang.format("A$1$", [value.format("%d")]);
       value = settings.notificationCount;
-      var noti_str = Lang.format("NOTIF $1$", [value.format("%d")]);
+      var noti_str = Lang.format("N$1$", [value.format("%d")]);
+
+      if (settings.phoneConnected) {
+         return Lang.format("$1$-$2$-C",[noti_str, alarm_str]);
+      } else {
+         return Lang.format("$1$-$2$-D",[noti_str, alarm_str]);
+      }
    }
 }


### PR DESCRIPTION
1. PhoneData.mc : GroupNotiField.cur_label() missing return value
2. ArcTextComplication: drawArcText() prevent fatal unexpected type error by checking for String instance before calling `.length()` 